### PR TITLE
Avoid hardcoding import paths

### DIFF
--- a/blender_scripts/render.py
+++ b/blender_scripts/render.py
@@ -3,10 +3,7 @@ import subprocess
 import os
 import shutil
 
-import sys
-sys.path.append('C:\\Users\\justi\\Documents\\CodeProjects\\Primer\\blender_scripts')
-sys.path.append('C:\\Users\\justi\\Documents\\CodeProjects\\Primer\\blender_scripts\\tools')
-import helpers
+from .tools import helpers
 
 overwrite = True
 
@@ -46,6 +43,7 @@ def render_with_skips(start, stop):
     # loop through each animated object and find its
     # animated frames. then remove those frames from
     # a set containing all frames, to get still frames.
+    fr_prev = None
     still_frames = set(render_range)
     for obj in all_obj_fcurves.keys():
         obj_animated_frames = []


### PR DESCRIPTION
__from .tools import helpers__ should do just fine.

Also, declare __fr_prev__ before its first use on line 52.  This is not strictly necessary with the current code but it is good defensive programming if the code changes in the future.